### PR TITLE
Use HTTP for RSS URLs

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -2,10 +2,10 @@
 title: Blog
 description: "The latest goings-on with the Polymer project and in the community. We'll update the blog to announce major releases and showcase cool stuff being built with Polymer."
 baseurl: ""
-url: "http://blog.polymer-project.com"
+url: "http://blog.polymer-project.org"
 twitter_username: polymer
 github_username:  polymer
-feed_url: "/feed.xml"
+feed_url: "http://blog.polymer-project.org/feed.xml"
 add_permalinks: true
 paginate: 5
 

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -5,6 +5,7 @@
     <meta name="viewport" content="width=device-width">
     <meta name="description" content="{{ site.description }}">
     <link rel="canonical" href="{{ page.url | replace:'index.html','' | prepend: site.baseurl | prepend: site.url }}">
+    <link rel="alternate" type="application/rss+xml" title="Polymer Blog Posts" href="http://blog.polymer-project.org/feed.xml">
 
     <!-- Custom CSS -->
     <link href="//fonts.googleapis.com/css?family=RobotoDraft:300,400,500|Source+Code+Pro:400,500,700" rel="stylesheet">


### PR DESCRIPTION
As per #7, there are issues accessing the site's RSS feed via HTTPS using Feedly (and anything else that doesn't play nicely with SNI certificates).

These changes force the HTTP protocol for the RSS feed link in the footer, and add in a `<link>` to the `<head>` pointing to the RSS feed (also using the HTTP protocol).

Even if we don't want to start forcing HTTP for the RSS feed link (despite the issue with Feedly), adding the `<link>` to `<head>` using a scheme-relative URL is still worth doing, and I can break that out in a separate PR.
