### PR TITLE
Rename carbon-route to app-route

### DIFF
--- a/_posts/2016-03-28-carbon-route-released.markdown
+++ b/_posts/2016-03-28-carbon-route-released.markdown
@@ -1,22 +1,24 @@
 ---
 layout: post
-title:  "carbon-route Beta Release"
+title:  "app-route Beta Release"
 date:   2016-03-28 10:30:00
 categories: announcements
 author: polymer-team
-excerpt: "The carbon-route element has made its beta debut - we'd love your feedback on this modular approach to routing."
+excerpt: "The app-route element has made its beta debut - we'd love your feedback on this modular approach to routing."
 
 ---
 
-We're excited to announce the beta release of the [`carbon-route`](https://github.com/polymerelements/carbon-route) element—a composable, modular web component router! To dive into this new element and see what it can do, check out the [Encapsulated Routing with Elements](https://www.polymer-project.org/1.0/articles/routing.html) article on the Polymer site and take a look at its [documentation in the Polymer Elements catalog](https://elements.polymer-project.org/browse?package=carbon-elements).
+> Note: app-route was previously called carbon-route. The carbon line of elements have been renamed the app elements to reflect their role as tools for building full client-side apps.
 
-The `carbon-route` element provides a declarative, modular way for web components to interact with the URL. This beta version is complete but may still evolve based on your feedback.
+We're excited to announce the beta release of the [`app-route`](https://github.com/polymerelements/app-route) element—a composable, modular web component router! To dive into this new element and see what it can do, check out the [Encapsulated Routing with Elements](https://www.polymer-project.org/1.0/articles/routing.html) article on the Polymer site and take a look at its [documentation in the Polymer Elements catalog](https://elements.polymer-project.org/browse?package=app-elements).
 
-Here's an example of how you can use the `carbon-route` (and its included `carbon-location`) element:
+The `app-route` element provides a declarative, modular way for web components to interact with the URL. This beta version is complete but may still evolve based on your feedback.
+
+Here's an example of how you can use the `app-route` (and its included `app-location`) element:
 
 {% raw %}
-    <carbon-location route="{{route}}"></carbon-location>
-    <carbon-route route="{{route}}" pattern="/tabs/:tabName" data="{{data}}"></carbon-route>
+    <app-location route="{{route}}"></app-location>
+    <app-route route="{{route}}" pattern="/tabs/:tabName" data="{{data}}"></app-route>
 
     <paper-tabs selected="{{data.tabName}}" attr-for-selected="key">
       <paper-tab key="foo">Foo</paper-tab>
@@ -35,4 +37,4 @@ Here's an example of how you can use the `carbon-route` (and its included `carbo
 {% endraw %}
 
 
-The `carbon-route` element is the first of the Polymer project's "carbon" product-line of components—a set designed to help encapsulate structured patterns for building large, complex applications using web components. Other elements that may fill out this product line—including i18n components—are still in their earlier stages. We'll being opening up these elements in a similar "beta" stage once they're at a point of stability to be able to receive meaningful feedback, and are targeting May to have the next handful of these components released. We'd also love to hear about the common application-level problems you run into when building web component-driven apps, that could form the basis of future carbon elements—please feel free to file issues on the [`carbon-elements` meta-repo](https://github.com/polymerelements/carbon-elements/issues) with ideas.
+The `app-route` element is part of the Polymer project's "app" product-line of components—a set designed to help encapsulate structured patterns for building large, complex applications using web components. Other elements that may fill out this product line—including i18n components—are still in their earlier stages. We'll being opening up these elements in a similar "beta" stage once they're at a point of stability to be able to receive meaningful feedback, and are targeting May to have the next handful of these components released. We'd also love to hear about the common application-level problems you run into when building web component-driven apps, that could form the basis of future app elements—please feel free to file issues on the [`app-elements` meta-repo](https://github.com/polymerelements/app-elements/issues) with ideas.


### PR DESCRIPTION
Part of https://github.com/PolymerElements/app-route/issues/100

The file keeps its name so our URLs will be the same, and I added a note at the top of the blog post about the rename. Otherwise, all references to `carbon-` have been changed to `app-`.

The link at the end of the article to the app-elements repo goes to a currently private repo, but hopefully that will be public very soon.
